### PR TITLE
[FIX] admin info update

### DIFF
--- a/smartcity_back/routes/apis.js
+++ b/smartcity_back/routes/apis.js
@@ -404,14 +404,14 @@ router.route('/users/:userId')
         if(concat){
           query+=",";
         }
-        query+="email=\'"+req.body.email+"\'";
+        query+=" email=\'"+req.body.email+"\'";
         concat = true;
       }
       if(req.body.phone)
       {
         if(concat)
           query+=",";
-        query+="phone=\'"+req.body.phone+"\'";
+        query+=" phone=\'"+req.body.phone+"\'";
       }
       query+=" WHERE user_id_pk=\'"+req.params.userId+"\'";
       DB.ByQuery(query,(err,result)=>{


### PR DESCRIPTION
# 1. 이슈
![image](https://github.com/user-attachments/assets/81f2b672-811f-49eb-8fd1-2c72812792da)

관리자 계정 정보에서 이메일 or 휴대폰 번호 변경 시 500 에러 발생

# 2. 원인
![image](https://github.com/user-attachments/assets/1481e72f-1368-4af8-b15c-5213a4976da8)

UPDATE 쿼리 생성 시, `SET` 다음에 공백 없음 발견

![image](https://github.com/user-attachments/assets/773a5c5d-870a-4843-b902-f61922e3408a)

`smartcity_back/routes/apis.js` 에서 402번 줄의 `nickname`은 공백으로 시작하지만 410, 417번 줄의 `email` 과 `phone` 은 공백이 없음

# 3. 해결
![image](https://github.com/user-attachments/assets/a1d86b9c-0dfc-40cd-84b7-ddaec7ba72cf)

410, 417번 줄의 `email` 과 `phone` 에 공백 추가

# 4. 로컬 테스트 결과
![image](https://github.com/user-attachments/assets/135bd4f7-1169-4870-9d38-25ad88205046)

이메일만 변경할 때 성공